### PR TITLE
fix: correct invalid semantic-release tagFormat

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -35,5 +35,5 @@
     ],
     "@semantic-release/github"
   ],
-  "tagFormat": "0.1.x"
+  "tagFormat": "v${version}"
 }


### PR DESCRIPTION
# Fix Invalid Semantic Release Tag Format

## Problem
The CI release job was failing due to an invalid `tagFormat` configuration in `.releaserc.json`. The error indicated that the `tagFormat` must contain the `version` variable exactly once, but it was set to a static value of "0.1.x".

## Changes
- Updated the `tagFormat` in `.releaserc.json` from `"0.1.x"` to `"v${version}"` to comply with semantic-release requirements
- This change allows semantic-release to properly generate version tags during the release process

## Type of Change
- [x] CI Configuration Fix
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation

## Testing
- The change will be verified through the CI pipeline running on this PR
- Success criteria: Release job should complete without the "Invalid `tagFormat` option" error

Link to Devin run: https://app.devin.ai/sessions/91163e12e651487fb8ca755b2c113e4d
